### PR TITLE
(personal placeholder) Q# Syntax highlighting for functions, variables and numbers

### DIFF
--- a/vscode/syntaxes/qsharp.tmLanguage.json
+++ b/vscode/syntaxes/qsharp.tmLanguage.json
@@ -94,7 +94,7 @@
         {
           "comment": "function calls",
           "name": "meta.function.call.qsharp",
-          "begin": "([A-Za-z0-9_]+)(\\()",
+          "begin": "\\b(?<!@)([A-Za-z0-9_]+)(\\()",
           "beginCaptures": {
             "1": {
               "name": "entity.name.function.qsharp"
@@ -202,7 +202,7 @@
       "patterns": [
         {
           "name": "variable.other.qsharp",
-          "match": "\\b[A-Za-z0-9_]+\\b"
+          "match": "\\b(?<!@)[A-Za-z0-9_]+\\b"
         }
       ]
     }

--- a/vscode/syntaxes/qsharp.tmLanguage.json
+++ b/vscode/syntaxes/qsharp.tmLanguage.json
@@ -23,6 +23,9 @@
     },
     {
       "include": "#strings"
+    },
+    {
+      "include": "#variables"
     }
   ],
   "repository": {
@@ -82,6 +85,9 @@
             },
             {
               "include": "#strings"
+            },
+            {
+              "include": "#variables"
             }
           ]
         },
@@ -124,6 +130,9 @@
             },
             {
               "include": "#strings"
+            },
+            {
+              "include": "#variables"
             }
           ]
         }
@@ -186,6 +195,14 @@
               "match": "\\\\."
             }
           ]
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "name": "variable.other.qsharp",
+          "match": "\\b[A-Za-z0-9_]+\\b"
         }
       ]
     }

--- a/vscode/syntaxes/qsharp.tmLanguage.json
+++ b/vscode/syntaxes/qsharp.tmLanguage.json
@@ -43,13 +43,41 @@
         {
           "comment": "function definition",
           "name": "meta.function.definition.qsharp",
-          "match": "\\b(function)\\s+([A-Za-z0-9_]+)",
-          "captures": {
+          "begin": "\\b(function)\\s+([A-Za-z0-9_]+)(\\()",
+          "beginCaptures": {
             "1": {
               "name": "keyword.other.qsharp"
             },
             "2": {
               "name": "entity.name.function.qsharp"
+            },
+            "3": {
+              "name": "punctuation.brackets.round.qsharp"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.qsharp"
+            }
+          }
+        },
+        {
+          "comment": "function calls",
+          "name": "meta.function.call.qsharp",
+          "begin": "([A-Za-z0-9_]+)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.qsharp"
+            },
+            "2": {
+              "name": "punctuation.brackets.round.qsharp"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.brackets.round.qsharp"
             }
           }
         }

--- a/vscode/syntaxes/qsharp.tmLanguage.json
+++ b/vscode/syntaxes/qsharp.tmLanguage.json
@@ -166,6 +166,11 @@
         {
           "name": "constant.other.result.qsharp",
           "match": "\\b(One|Zero)\\b"
+        },
+        {
+          "comment": "integers and decimals",
+          "name": "constant.numeric.qsharp",
+          "match": "\\b[\\d_]*\\.?[\\d_]\\b"
         }
       ]
     },

--- a/vscode/syntaxes/qsharp.tmLanguage.json
+++ b/vscode/syntaxes/qsharp.tmLanguage.json
@@ -7,6 +7,9 @@
       "include": "#comments"
     },
     {
+      "include": "#functions"
+    },
+    {
       "include": "#keywords"
     },
     {
@@ -32,6 +35,23 @@
         {
           "name": "comment.documentation",
           "match": "\\/\\/\\/.*$"
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "comment": "function definition",
+          "name": "meta.function.definition.qsharp",
+          "match": "\\b(function)\\s+([A-Za-z0-9_]+)",
+          "captures": {
+            "1": {
+              "name": "keyword.other.qsharp"
+            },
+            "2": {
+              "name": "entity.name.function.qsharp"
+            }
+          }
         }
       ]
     },

--- a/vscode/syntaxes/qsharp.tmLanguage.json
+++ b/vscode/syntaxes/qsharp.tmLanguage.json
@@ -60,7 +60,30 @@
             "0": {
               "name": "punctuation.brackets.round.qsharp"
             }
-          }
+          },
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#strings"
+            }
+          ]
         },
         {
           "comment": "function calls",
@@ -79,7 +102,30 @@
             "0": {
               "name": "punctuation.brackets.round.qsharp"
             }
-          }
+          },
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#strings"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Supports syntax highlighting for:
- function definitions
- function calls
- numbers
- variables

See ... (?).

The change of function calls also colors operation definitions as well as attributes (see bigger example below).
The change to the variables also colors attributes, as well as to imports.
If desired, these can probably be fixed by making designated rules. I can do those here, but I think it might be best as a followup issue.

Simple example for the change (from the original issue description):

![image](https://github.com/user-attachments/assets/5dad08d3-e86e-4602-b3fd-b18d1406b775)

Bigger example:

![image](https://github.com/user-attachments/assets/d956298a-9c42-4b6a-9c9f-0ea21f3d40b1)
