### PR TITLE
Consecutive-qubit circuit art - placeholder

### DIFF
--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -490,18 +490,25 @@ fn custom_intrinsic_mixed_args() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // This is one gate that spans ten target wires, even though the
-    // text visualization doesn't convey that clearly.
     expect![[r"
         q_0    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_1    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_2    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_3    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_4    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_5    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_6    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_7    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_8    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+                                                         ┆
         q_9    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
     "]]
     .assert_eq(&circ.to_string());
@@ -883,6 +890,82 @@ fn operation_with_long_gates_properly_aligned() {
         q_2    ── H ─── rx(1.0000) ──────── H ─────── rx(1.0000) ──── H ─── rx(1.0000) ─────────┆──────────┼──────────
         q_3    ─────────────────────────────────────────────────────────────────────────── rxx(1.0000) ─── X ──── M ──
                                                                                                                   ╘═══
+    "#]]
+    .assert_eq(&circ.to_string());
+}
+
+#[test]
+fn operation_with_subsequent_qubits_gets_horizontal_lines() {
+    let mut interpreter = interpreter(
+        r"
+            namespace Test {
+                import Std.Measurement.*;
+
+                @EntryPoint()
+                operation Main() : Unit {
+                    use q0 = Qubit();
+                    use q1 = Qubit();
+                    Rxx(1.0, q0, q1);
+
+                    use q2 = Qubit();
+                    use q3 = Qubit();
+                    Rxx(1.0, q2, q3);
+                }
+            }
+        ",
+        Profile::Unrestricted,
+    );
+
+    let circ = interpreter
+        .circuit(CircuitEntryPoint::EntryPoint, false)
+        .expect("circuit generation should succeed");
+
+    expect![[r#"
+        q_0    ─ rxx(1.0000) ─
+                      ┆
+        q_1    ─ rxx(1.0000) ─
+        q_2    ─ rxx(1.0000) ─
+                      ┆
+        q_3    ─ rxx(1.0000) ─
+    "#]]
+    .assert_eq(&circ.to_string());
+}
+
+#[test]
+fn operation_with_subsequent_qubits_no_empty_rows() {
+    let mut interpreter = interpreter(
+        r"
+            namespace Test {
+                import Std.Measurement.*;
+
+                @EntryPoint()
+                operation Main() : Result[] {
+                    use q0 = Qubit();
+                    use q1 = Qubit();
+                    Rxx(1.0, q0, q1);
+
+                    use q2 = Qubit();
+                    use q3 = Qubit();
+                    Rxx(1.0, q2, q3);
+
+                    [M(q0), M(q2)]
+                }
+            }
+        ",
+        Profile::Unrestricted,
+    );
+
+    let circ = interpreter
+        .circuit(CircuitEntryPoint::EntryPoint, false)
+        .expect("circuit generation should succeed");
+
+    expect![[r#"
+        q_0    ─ rxx(1.0000) ─── M ──
+                      ┆          ╘═══
+        q_1    ─ rxx(1.0000) ────────
+        q_2    ─ rxx(1.0000) ─── M ──
+                      ┆          ╘═══
+        q_3    ─ rxx(1.0000) ────────
     "#]]
     .assert_eq(&circ.to_string());
 }


### PR DESCRIPTION
This PR both fixes issue ..., and reworks some of the code based on comments from ...

The main change is that now for a case like this one:
```
use q0 = Qubit();
use q1 = Qubit();
Rxx(1.0, q0, q1);
Rxx(1.0, q0, q1);
```
instead of getting
```
q_0    ─ rxx(1.0000) ─
q_1    ─ rxx(1.0000) ─
q_2    ─ rxx(1.0000) ─
q_3    ─ rxx(1.0000) ─
```
we get 
```
q_0    ─ rxx(1.0000) ─
              ┆
q_1    ─ rxx(1.0000) ─
q_2    ─ rxx(1.0000) ─
              ┆
q_3    ─ rxx(1.0000) ─
```
which is similar to what we would have gotten in the old code (and still get in the new code), if we measure the upper qubit of each two-qubit gate, i.e.
```
q_0    ─ rxx(1.0000) ─── M ──
              ┆          ╘═══
q_1    ─ rxx(1.0000) ────────
q_2    ─ rxx(1.0000) ─── M ──
              ┆          ╘═══
q_3    ─ rxx(1.0000) ────────
```

It's probably best to review it commit by commit, for two reason - a. it's going to be much easier to follow, and b. any of these commits can be reverted if you think they make the code more complicated instead of less.

Commits are as follows:
1. [a400655](https://github.com/Morcifer/qsharp/pull/3/commits/a4006557b4b0fcd0bacd14c5c1142eeecefbaa76) A rework of PR ..., which, to be honest, is how I think I should have done it in the first place.
2. [c141799](https://github.com/Morcifer/qsharp/pull/3/commits/c14179907ed45ebd02e07199db85a401edaf61b1) A cleanup based on ...'s comment here. It makes the code significantly easier to understand.
3. [4012ee8](https://github.com/Morcifer/qsharp/pull/3/commits/4012ee8378f0080cf79b2220dead041ccc964edf) A small simplification to have a `new` which is in charge of making sure that the column width is odd, and also a `Default` trait implementation for the case where we don't need a specific width.
4. [cfa7382](https://github.com/Morcifer/qsharp/pull/3/commits/cfa7382630b83ee0aefd64ee414ca6b5b600f2d2) This is the actual enhancement - it makes sure there is a classical line (same as what you get from a measurement) if there are two consecutive qubits for the same operation.